### PR TITLE
Change the download location to temp dir instead of downloads

### DIFF
--- a/install/install.bat
+++ b/install/install.bat
@@ -1,6 +1,6 @@
 @echo off
 
-powershell -command "iwr 'https://github.com/DarthKillian/eti-tools/releases/latest/download/netpro.zip' -OutFile '%userprofile%\Downloads\netpro.zip'; Expand-Archive '%userprofile%\Downloads\netpro.zip' -DestinationPath 'C:\ProgramData\netpro' -Force; & copy 'C:\ProgramData\netpro\netpro.bat' '%userprofile%\Desktop';"
+powershell -command "iwr 'https://github.com/DarthKillian/eti-tools/releases/latest/download/netpro.zip' -OutFile '%temp%\netpro.zip'; Expand-Archive '%temp%\netpro.zip' -DestinationPath 'C:\ProgramData\netpro' -Force; & copy 'C:\ProgramData\netpro\netpro.bat' '%userprofile%\Desktop';"
 
 echo Download and install completed. Press any key to launch netpro and exit the installer...
 


### PR DESCRIPTION
This changes the script download location to the temp directory instead of the download directory to not pollute the user's download folder.